### PR TITLE
remove use of Object.keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,22 @@ A better forEach.
 
 ## Example
 
-Like `Array.prototype.forEach` but works on objects
+Like `Array.prototype.forEach` but works on objects.
 
-``` js
+```js
 var forEach = require("for-each")
 
-forEach({ key: "value" }, function (value, key) {
+forEach({ key: "value" }, function (value, key, object) {
+    /* code */
+})
+```
+
+As a bonus, it's also a perfectly function shim/polyfill for arrays too!
+
+```js
+var forEach = require("for-each")
+
+forEach([1, 2, 3], function (value, index, array) {
     /* code */
 })
 ```

--- a/index.js
+++ b/index.js
@@ -1,25 +1,44 @@
 module.exports = forEach
 
 var toString = Object.prototype.toString
+var hasOwnProperty = Object.prototype.hasOwnProperty
 
 function forEach(list, iterator, context) {
     if (toString.call(iterator) !== '[object Function]') {
         throw new TypeError('iterator must be a function')
     }
 
-    var isArray = toString.call(list) === '[object Array]'
-        , isString = typeof list === 'string'
-        , keys = isString ? list : Object.keys(list)
-
     if (arguments.length < 3) {
         context = this
     }
+    
+    if (toString.call(list) === '[object Array]')
+        forEachArray(list, iterator, context)
+    else if (typeof list === 'string')
+        forEachString(list, iterator, context)
+    else
+        forEachObject(list, iterator, context)
+}
 
-    for (var i = 0, len = keys.length; i < len; i++) {
-        var key = isString || isArray ? i : keys[i]
-            , value = isString ? keys.charAt(i) : list[key]
-
-        iterator.call(context, value, key, list)
+function forEachArray(array, iterator, context) {
+    for (var i = 0, len = array.length; i < len; i++) {
+        if (hasOwnProperty.call(array, i)) {
+            iterator.call(context, array[i], i, array)
+        }
     }
 }
 
+function forEachString(string, iterator, context) {
+    for (var i = 0, len = string.length; i < len; i++) {
+        // no such thing as a sparse string.
+        iterator.call(context, string.charAt(i), i, string)
+    }
+}
+
+function forEachObject(object, iterator, context) {
+    for (var k in object) {
+        if (hasOwnProperty.call(object, k)) {
+            iterator.call(context, object[k], k, object)
+        }
+    }
+}


### PR DESCRIPTION
This is something of a rewrite, but has the following improvements:
- More correct treatment of sparse arrays
- Can be used in browsers with Object.keys
- Can be used to _implement_ Object.keys
- Separates the implementations for each iterable thing for clarity/readability

This comes with some tradeoffs though:
- Tiny bit of code duplication
- Possibly slower due to the extra function call. If this is an issue
  each implementation could easily be inlined.
